### PR TITLE
[PKG-6899] 1.15.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-# upload_without_merge: True
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - makefun
   commands:
     - pip check
+    - pytest
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/smarie/python-makefun

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "makefun" %}
-{% set version = "1.15.1" %}
-
+{% set version = "1.15.6" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/makefun-{{ version }}.tar.gz
-  sha256: 40b0f118b6ded0d8d78c78f1eb679b8b6b2462e3c1b3e05fb1b2da8cd46b48a5
+  sha256: 26bc63442a6182fb75efed8b51741dd2d1db2f176bec8c64e20a586256b8f149
 
 build:
   skip: true  # [py<35]


### PR DESCRIPTION
makefun 1.15.6

**Destination channel:** defaults
### Links

- [PKG-6899] 
- [Upstream repository](https://github.com/smarie/python-makefun)
- [Upstream changelog/diff](https://smarie.github.io/python-makefun/changelog/)

### Explanation of changes:

- Set upload to defaults.
- Added upstream tests
- Enabled Python 3.13 build


[PKG-6899]: https://anaconda.atlassian.net/browse/PKG-6899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ